### PR TITLE
Constrain generic constant

### DIFF
--- a/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
@@ -134,7 +134,7 @@ where
 			assert!(data_piece.len() <= k2);
 			let encoding_run = self.encode_sub(data_piece)?;
 			for val_idx in 0..validator_count {
-				AsMut::<[[u8; 2]]>::as_mut(&mut shards[val_idx])[chunk_idx] = encoding_run[val_idx] as [u8; 2];
+				AsMut::<[[u8; F::FIELD_BYTES]]>::as_mut(&mut shards[val_idx])[chunk_idx] = encoding_run[val_idx];
 			}
 		}
 
@@ -169,7 +169,7 @@ where
 				.enumerate()
 				.find_map(|(idx, shard)| {
 					shard.as_ref().map(|shard| {
-						let shard = AsRef::<[[u8; 2]]>::as_ref(shard);
+						let shard = AsRef::<[[u8; F::FIELD_BYTES]]>::as_ref(shard);
 						(idx, shard.len())
 					})
 				})
@@ -178,7 +178,7 @@ where
 			// make sure all shards have the same length as the first one
 			if let Some(other_shard_len) = received_shards[(first_shard_idx + 1)..].iter().find_map(|shard| {
 				shard.as_ref().and_then(|shard| {
-					let shard = AsRef::<[[u8; 2]]>::as_ref(shard);
+					let shard = AsRef::<[[u8; F::FIELD_BYTES]]>::as_ref(shard);
 					if first_shard_len != shard.len() {
 						Some(shard.len())
 					} else {
@@ -204,7 +204,7 @@ where
 				.iter()
 				.map(|x| {
 					x.as_ref().map(|x| {
-						let z = AsRef::<[[u8; 2]]>::as_ref(&x)[i];
+						let z = AsRef::<[[u8; F::FIELD_BYTES]]>::as_ref(&x)[i];
 						Additive(u16::from_be_bytes(z))
 					})
 				})

--- a/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
+++ b/reed-solomon-novelpoly/src/novel_poly_basis/mod.rs
@@ -46,7 +46,10 @@ pub struct ReedSolomon<F: AfftField> {
     _marker: PhantomData<*const F>,
 }
 
-impl <F: AfftField> ReedSolomon<F> {
+impl <F: AfftField> ReedSolomon<F>
+where
+	[u8; F::FIELD_BYTES]: Sized,
+{
 
     /// Returns the total number of data shard
     /// consumed by the code. That is equal the total number of symbols

--- a/reed-solomon-novelpoly/src/shard.rs
+++ b/reed-solomon-novelpoly/src/shard.rs
@@ -7,8 +7,9 @@ use crate::field::FieldAdd;
 //     where [(); <F as FieldAdd>::FIELD_BYTES]: Sized
 
 pub trait Shard<F: FieldAdd>:
-Clone + AsRef<[u8]> + AsMut<[u8]> + AsMut<[F::Element]> + AsRef<F::Element> + iter::FromIterator<F::Element> + From<Vec<u8>>
-//    where F::Element : Sized
+Clone + AsRef<[u8]> + AsMut<[u8]> + AsMut<[[u8; F::FIELD_BYTES]]> + AsRef<F::Element> + iter::FromIterator<F::Element> + From<Vec<u8>>
+where
+	[u8; F::FIELD_BYTES]: Sized,
 {
   	type Inner;
   	fn into_inner(self) -> Self::Inner;


### PR DESCRIPTION
https://stackoverflow.com/questions/66361365/unconstrained-generic-constant-when-adding-const-generics

Don't ask me why :)

This is still open:

```rust
error[E0277]: the trait bound `S: AsRef<[[u8; _]]>` is not satisfied
   --> reed-solomon-novelpoly/src/novel_poly_basis/mod.rs:181:58
    |
181 |                     let shard = AsRef::<[[u8; F::FIELD_BYTES]]>::as_ref(shard);
    |                                                                         ^^^^^ the trait `AsRef<[[u8; _]]>` is not implemented for `S`
    |
    = note: required by `as_ref`
help: consider further restricting this bound
    |
145 |     pub fn reconstruct<S: Shard<F> + std::convert::AsRef<[[u8; _]]>>(&self, received_shards: Vec<Option<S>>) -> Result<Vec<u8>> {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


```